### PR TITLE
Fixed configuration file support & Added new test case for parsing configuration file

### DIFF
--- a/config.js
+++ b/config.js
@@ -1,12 +1,14 @@
 /* eslint-disable */
-
+import { Main } from "./main.js";
 import fs from "fs";
 
-export function Config(arr) {
+export function Config(options) {
   let configPath = options.config;
   if (configPath) {
     const config_file = fs.readFileSync(configPath);
     const parsed = JSON.parse(config_file);
+    let style;
+    let filename;
     if (parsed.input) {
       if (parsed.stylesheet) {
         style = parsed.stylesheet;
@@ -14,6 +16,13 @@ export function Config(arr) {
         style = "";
       }
       filename = parsed.input;
+      let file = {
+        _: [],
+        i: `${parsed.input}`,
+        input: `${parsed.input}`,
+        $0: "",
+      };
+      Main(file);
     } else {
       console.log("Missing input path to a file or directory in config file");
       exit();

--- a/main.js
+++ b/main.js
@@ -90,16 +90,15 @@ export function Main(file) {
       path.join(srcPath, "template.html"),
       "utf8"
     );
-
-    if (file.input.includes(".")) {
+    if (file.config) {
+      Config(file);
+    } else if (file.input.includes(".")) {
       const filenames = glob.sync(srcPath + `/**/${file.input}`);
       filenames.forEach((filename) => {
         if (filename.includes("txt")) {
           processFile(filename, template, outPath);
         } else if (filename.includes("md")) {
           processFile_md(filename, template, outPath);
-        } else if (filename.includes(".json")) {
-          Config();
         }
       });
     } else {

--- a/options.js
+++ b/options.js
@@ -22,7 +22,7 @@ export function Options() {
 
     if (options.input === undefined || options.input === null) {
       throw new Error(
-        `error: Option isn't corect. Please provide correct input`
+        `error: Option isn't correct. Please provide correct input`
       );
     }
     return options;

--- a/options.js
+++ b/options.js
@@ -20,11 +20,12 @@ export function Options() {
       .version("v", "version", "qck-ssg v0.1.2")
       .alias("s", "stylesheet").argv;
 
-    if (options.input === undefined || options.input === null) {
+    if (options.config === undefined && options.input === undefined) {
       throw new Error(
         `error: Option isn't correct. Please provide correct input`
       );
     }
+
     return options;
   }
 

--- a/options.test.js
+++ b/options.test.js
@@ -15,7 +15,7 @@ describe("Options tests", () => {
     });
     expect(() => {
       Options();
-    }).toThrow(`error: Option isn't corect. Please provide correct input`);
+    }).toThrow(`error: Option isn't correct. Please provide correct input`);
   });
 
   test("With input options should not throw error", async () => {

--- a/test/__snapshots__/e2e.test.js.snap
+++ b/test/__snapshots__/e2e.test.js.snap
@@ -12,6 +12,8 @@ Options:
 
 exports[`end-to-end integration prints version message when --version given 1`] = `"qck-ssg v0.1.2"`;
 
+exports[`end-to-end integration single valid json configuration file should generate an html 1`] = `"-- Link to Page Created In Index File"`;
+
 exports[`end-to-end integration single valid text file input should generate an html 1`] = `"-- Link to Page Created In Index File"`;
 
 exports[`end-to-end integration single valid text file input should generate an html 2`] = `"-- Link to Page Created In Index File"`;

--- a/test/e2e.test.js
+++ b/test/e2e.test.js
@@ -46,7 +46,6 @@ describe("end-to-end integration", () => {
 
   test("single valid json configuration file should generate an html", async () => {
     const { stderr, stdout, exitCode } = await run("--config", "src/conf.json");
-    console.log(stderr);
     expect(exitCode).toBe(0);
     expect(stdout).toMatchSnapshot();
     expect(stderr).toEqual("");

--- a/test/e2e.test.js
+++ b/test/e2e.test.js
@@ -4,7 +4,8 @@ const { run } = require("./run");
 describe("end-to-end integration", () => {
   test("prints error and help message when no arguments given", async () => {
     const { stderr, stdout, exitCode } = await run();
-    const errorMsg = "error: Option isn't corect. Please provide correct input";
+    const errorMsg =
+      "error: Option isn't correct. Please provide correct input";
     expect(exitCode === 0).toBeFalsy();
     expect(stderr.includes(errorMsg)).toBeTruthy();
     expect(stdout).toEqual("");
@@ -38,6 +39,14 @@ describe("end-to-end integration", () => {
       "--stylesheet",
       "link"
     );
+    expect(exitCode).toBe(0);
+    expect(stdout).toMatchSnapshot();
+    expect(stderr).toEqual("");
+  });
+
+  test("single valid json configuration file should generate an html", async () => {
+    const { stderr, stdout, exitCode } = await run("--config", "src/conf.json");
+    console.log(stderr);
     expect(exitCode).toBe(0);
     expect(stdout).toMatchSnapshot();
     expect(stderr).toEqual("");


### PR DESCRIPTION
Hello @aserputov ! 

## What changes are proposed in this pull request?
Solves issue #17 

I have added a test case for testing Command Line Parser. Specifically, I added a test case which checks the performance of the tool if we provide a json object as a config file.

When I was creating a test case, I have found a bug in the tool in config parser. I have fixed configuration file support of the tool
What have been done:
- Fixed typos 
- Fixed configuration file support 
- Added unit test that checks command line parser for configuration files.